### PR TITLE
Add #TheBeatles hashtag to Twitter

### DIFF
--- a/beatles_lyrics_bot.py
+++ b/beatles_lyrics_bot.py
@@ -46,11 +46,12 @@ def random_line(afile):
 try:
     with open('data/lyrics.txt', 'r', encoding="UTF-8") as f:
         rline = random_line(f).split('\n')[0]
+        rline = f'{rline} #TheBeatles'
 
         # print(rline)
         try:
             twitter.update_status(status=rline)
-            mastodon.toot(f'{rline} #TheBeatles')
+            mastodon.toot(rline)
         except TwythonError as e:
             logging.error("Couldn't send the tweet: %s", e)
 except OSError:


### PR DESCRIPTION
It was previously only added in posts sent to Mastodon and it has been a success over there, making the Mastodon account surpass the Twitter account in followers in record time. Hopefully, this will make te Twitter account more discoverable.